### PR TITLE
Add support for column type changes

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -431,7 +431,19 @@ func generateAlterTable(current, desired *Table) []string {
 		}
 	}
 
-	// TODO: Handle column type changes (requires more complex logic in Spanner)
+	// Handle column type changes
+	for colName, desiredCol := range desired.Columns {
+		if currentCol, exists := current.Columns[colName]; exists {
+			// Check if column type has changed
+			if currentCol.Type != desiredCol.Type {
+				def := fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s %s", desired.Name, colName, desiredCol.Type)
+				if desiredCol.NotNull {
+					def += " NOT NULL"
+				}
+				ddls = append(ddls, def)
+			}
+		}
+	}
 
 	return ddls
 }

--- a/spannerdef_test.go
+++ b/spannerdef_test.go
@@ -450,6 +450,31 @@ func TestSpannerSpecificFeatures(t *testing.T) {
 		ddls = applySchema(t, db, schema, false)
 		assert.Empty(t, ddls, "Schema with DEFAULT clauses should be idempotent")
 	})
+
+	t.Run("ColumnTypeChange", func(t *testing.T) {
+		db := recreateDatabase(t, config)
+		defer db.Close()
+
+		// Initial schema
+		initialSchema := `
+			CREATE TABLE Users (
+				Id INT64 NOT NULL,
+				Name STRING(100)
+			) PRIMARY KEY (Id);
+		`
+		applySchema(t, db, initialSchema, false)
+
+		// Change column type
+		updatedSchema := `
+			CREATE TABLE Users (
+				Id INT64 NOT NULL,
+				Name STRING(200)
+			) PRIMARY KEY (Id);
+		`
+
+		ddls := applySchema(t, db, updatedSchema, false)
+		assertDDLContains(t, ddls, "ALTER TABLE Users ALTER COLUMN Name STRING(200)")
+	})
 }
 
 // TestEdgeCases tests edge cases and error conditions


### PR DESCRIPTION
Implements ALTER COLUMN DDL generation when column types change between current and desired schemas. Includes test case to verify functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)