### PR TITLE
Parse ALTER TABLE ADD CONSTRAINT when loading current schema

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -77,26 +77,32 @@ func ParseDDLs(ddls string) (*Schema, error) {
 		return nil, fmt.Errorf("failed to parse DDLs: %v", err)
 	}
 
+	// Two passes: create tables/indexes first, then apply alterations.
+	// Spanner's GetDatabaseDdl emits foreign keys as separate ALTER TABLE
+	// statements, and the statements may not be ordered so that tables
+	// precede their own ALTERs (in particular, spanner.DumpDDLs sorts them
+	// alphabetically, which puts ALTER before CREATE).
 	for _, stmt := range parsed {
-		if err := processStatement(schema, stmt); err != nil {
-			return nil, fmt.Errorf("failed to process statement: %v", err)
+		switch s := stmt.(type) {
+		case *ast.CreateTable:
+			if err := processCreateTable(schema, s); err != nil {
+				return nil, fmt.Errorf("failed to process statement: %v", err)
+			}
+		case *ast.CreateIndex:
+			if err := processCreateIndex(schema, s); err != nil {
+				return nil, fmt.Errorf("failed to process statement: %v", err)
+			}
+		}
+	}
+	for _, stmt := range parsed {
+		if s, ok := stmt.(*ast.AlterTable); ok {
+			if err := processAlterTable(schema, s); err != nil {
+				return nil, fmt.Errorf("failed to process statement: %v", err)
+			}
 		}
 	}
 
 	return schema, nil
-}
-
-// processStatement processes a parsed DDL statement
-func processStatement(schema *Schema, stmt ast.DDL) error {
-	switch s := stmt.(type) {
-	case *ast.CreateTable:
-		return processCreateTable(schema, s)
-	case *ast.CreateIndex:
-		return processCreateIndex(schema, s)
-	default:
-		// Ignore other DDL types for now
-		return nil
-	}
 }
 
 // processCreateTable processes CREATE TABLE statement
@@ -140,49 +146,7 @@ func processCreateTable(schema *Schema, stmt *ast.CreateTable) error {
 
 	// Process table constraints
 	for _, tc := range stmt.TableConstraints {
-		constraintName := ""
-		if tc.Name != nil {
-			constraintName = tc.Name.Name
-		}
-
-		switch c := tc.Constraint.(type) {
-		case *ast.Check:
-			if constraintName == "" {
-				// Generate a name if not specified
-				constraintName = fmt.Sprintf("CK_%s_%d", tableName, len(table.Constraints))
-			}
-			table.Constraints[constraintName] = &Constraint{
-				Name:       constraintName,
-				Type:       "CHECK",
-				Expression: "(" + c.Expr.SQL() + ")",
-			}
-		case *ast.ForeignKey:
-			if constraintName == "" {
-				// Generate a name if not specified
-				constraintName = fmt.Sprintf("FK_%s_%d", tableName, len(table.Constraints))
-			}
-
-			// Extract column names
-			var columns []string
-			for _, col := range c.Columns {
-				columns = append(columns, col.Name)
-			}
-
-			// Extract reference columns
-			var refColumns []string
-			for _, col := range c.ReferenceColumns {
-				refColumns = append(refColumns, col.Name)
-			}
-
-			table.Constraints[constraintName] = &Constraint{
-				Name:             constraintName,
-				Type:             "FOREIGN KEY",
-				Columns:          columns,
-				ReferenceTable:   getPathName(c.ReferenceTable),
-				ReferenceColumns: refColumns,
-				OnDelete:         string(c.OnDelete),
-			}
-		}
+		registerTableConstraint(table, tc)
 	}
 
 	// Process interleave information
@@ -208,6 +172,70 @@ func processCreateTable(schema *Schema, stmt *ast.CreateTable) error {
 
 	schema.Tables[tableName] = table
 	return nil
+}
+
+// processAlterTable processes ALTER TABLE statement. Only the actions that
+// affect the schema model (currently ADD CONSTRAINT) are handled — others
+// are ignored so round-tripping DDL from Spanner/Omni's GetDatabaseDdl does
+// not error out.
+func processAlterTable(schema *Schema, stmt *ast.AlterTable) error {
+	tableName := getPathName(stmt.Name)
+	table, ok := schema.Tables[tableName]
+	if !ok {
+		return nil
+	}
+
+	if add, ok := stmt.TableAlteration.(*ast.AddTableConstraint); ok && add.TableConstraint != nil {
+		registerTableConstraint(table, add.TableConstraint)
+	}
+
+	return nil
+}
+
+// registerTableConstraint records a CHECK or FOREIGN KEY constraint on a table.
+// Shared between CREATE TABLE parsing and ALTER TABLE ADD CONSTRAINT parsing —
+// Spanner's GetDatabaseDdl returns foreign keys as separate ALTER TABLE
+// statements, so both entry points must produce the same in-memory shape.
+func registerTableConstraint(table *Table, tc *ast.TableConstraint) {
+	constraintName := ""
+	if tc.Name != nil {
+		constraintName = tc.Name.Name
+	}
+
+	switch c := tc.Constraint.(type) {
+	case *ast.Check:
+		if constraintName == "" {
+			constraintName = fmt.Sprintf("CK_%s_%d", table.Name, len(table.Constraints))
+		}
+		table.Constraints[constraintName] = &Constraint{
+			Name:       constraintName,
+			Type:       "CHECK",
+			Expression: "(" + c.Expr.SQL() + ")",
+		}
+	case *ast.ForeignKey:
+		if constraintName == "" {
+			constraintName = fmt.Sprintf("FK_%s_%d", table.Name, len(table.Constraints))
+		}
+
+		var columns []string
+		for _, col := range c.Columns {
+			columns = append(columns, col.Name)
+		}
+
+		var refColumns []string
+		for _, col := range c.ReferenceColumns {
+			refColumns = append(refColumns, col.Name)
+		}
+
+		table.Constraints[constraintName] = &Constraint{
+			Name:             constraintName,
+			Type:             "FOREIGN KEY",
+			Columns:          columns,
+			ReferenceTable:   getPathName(c.ReferenceTable),
+			ReferenceColumns: refColumns,
+			OnDelete:         string(c.OnDelete),
+		}
+	}
 }
 
 // processCreateIndex processes CREATE INDEX statement

--- a/parser_test.go
+++ b/parser_test.go
@@ -1085,3 +1085,97 @@ ROW DELETION POLICY (OLDER_THAN(event_date, INTERVAL 90 DAY))`
 
 	assert.Equal(t, expectedDDL, ddls[0])
 }
+
+// Spanner's GetDatabaseDdl (and Spanner Omni) returns foreign-key
+// constraints as standalone ALTER TABLE ADD CONSTRAINT statements rather
+// than inline inside CREATE TABLE. The parser must fold these back into
+// the referenced table so that diffing against the desired schema reports
+// no changes.
+func TestParseDDLs_AlterTableAddForeignKey(t *testing.T) {
+	ddl := `
+		ALTER TABLE posts ADD CONSTRAINT fk_user FOREIGN KEY(user_id) REFERENCES users(id);
+
+		CREATE TABLE users (
+			id STRING(36) NOT NULL
+		) PRIMARY KEY (id);
+
+		CREATE TABLE posts (
+			id STRING(36) NOT NULL,
+			user_id STRING(36) NOT NULL
+		) PRIMARY KEY (id);
+	`
+
+	schema, err := ParseDDLs(ddl)
+	require.NoError(t, err)
+
+	posts, exists := schema.Tables["posts"]
+	require.True(t, exists)
+
+	c, exists := posts.Constraints["fk_user"]
+	require.True(t, exists, "fk_user constraint should be registered on posts")
+	assert.Equal(t, "FOREIGN KEY", c.Type)
+	assert.Equal(t, []string{"user_id"}, c.Columns)
+	assert.Equal(t, "users", c.ReferenceTable)
+	assert.Equal(t, []string{"id"}, c.ReferenceColumns)
+}
+
+func TestParseDDLs_AlterTableAddCheck(t *testing.T) {
+	ddl := `
+		CREATE TABLE items (
+			id INT64 NOT NULL,
+			qty INT64 NOT NULL
+		) PRIMARY KEY (id);
+
+		ALTER TABLE items ADD CONSTRAINT ck_qty CHECK (qty > 0);
+	`
+
+	schema, err := ParseDDLs(ddl)
+	require.NoError(t, err)
+
+	items := schema.Tables["items"]
+	require.NotNil(t, items)
+
+	c, exists := items.Constraints["ck_qty"]
+	require.True(t, exists)
+	assert.Equal(t, "CHECK", c.Type)
+	assert.Contains(t, c.Expression, "qty")
+}
+
+// When the parsed DDL already matches the desired schema (including
+// foreign keys emitted as standalone ALTER TABLE statements), GenerateDDLs
+// must produce no diff. This guards against the regression where Spanner
+// Omni's GetDatabaseDdl output caused a spurious ADD CONSTRAINT on every
+// apply.
+func TestGenerateDDLs_NoDiffWhenForeignKeyEmittedAsAlterTable(t *testing.T) {
+	currentDDL := `
+		ALTER TABLE posts ADD CONSTRAINT fk_user FOREIGN KEY(user_id) REFERENCES users(id);
+
+		CREATE TABLE users (
+			id STRING(36) NOT NULL
+		) PRIMARY KEY (id);
+
+		CREATE TABLE posts (
+			id STRING(36) NOT NULL,
+			user_id STRING(36) NOT NULL
+		) PRIMARY KEY (id);
+	`
+	desiredDDL := `
+		CREATE TABLE users (
+			id STRING(36) NOT NULL
+		) PRIMARY KEY (id);
+
+		CREATE TABLE posts (
+			id STRING(36) NOT NULL,
+			user_id STRING(36) NOT NULL,
+			CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES users (id)
+		) PRIMARY KEY (id);
+	`
+
+	current, err := ParseDDLs(currentDDL)
+	require.NoError(t, err)
+	desired, err := ParseDDLs(desiredDDL)
+	require.NoError(t, err)
+
+	ddls := GenerateDDLs(current, desired)
+	assert.Empty(t, ddls, "expected no diff, got: %v", ddls)
+}


### PR DESCRIPTION
## Summary
- Fix a bug where a schema containing a foreign key was never idempotent: every re-apply against real Spanner (or Spanner Omni, which matches prod) emitted a fresh \`ALTER TABLE ... ADD CONSTRAINT ...\`.
- Root cause: \`ParseDDLs\` ignored \`*ast.AlterTable\`, so foreign keys returned by \`GetDatabaseDdl\` as standalone \`ALTER TABLE ADD CONSTRAINT\` statements were dropped from the in-memory current schema.
- Fix:
  - Handle \`*ast.AlterTable\` (currently \`AddTableConstraint\`) and fold the constraint back onto the target table.
  - Process \`CREATE\` before \`ALTER\` in two passes so the target table exists regardless of ordering (\`spanner.DumpDDLs\` sorts alphabetically, so \`ALTER\` ends up before \`CREATE\`).
  - Extract CHECK / FOREIGN KEY registration into a shared \`registerTableConstraint\` helper used by both \`processCreateTable\` and \`processAlterTable\`.

## Why this was not caught by existing tests
The Spanner Emulator (1.5.x) returns foreign keys inline inside \`CREATE TABLE\` from \`GetDatabaseDdl\`, which the old parser happened to handle correctly. Real Spanner and Spanner Omni return them as standalone \`ALTER TABLE\` statements, so the diff only showed up outside of CI.

## Test plan
- [x] New unit tests: \`TestParseDDLs_AlterTableAddForeignKey\`, \`TestParseDDLs_AlterTableAddCheck\`, \`TestGenerateDDLs_NoDiffWhenForeignKeyEmittedAsAlterTable\`.
- [x] Full test suite still green against the Spanner Emulator (\`SPANNER_EMULATOR_HOST=localhost:9010 go test ./...\`).
- [x] Manual end-to-end against Spanner Omni: applying a schema with a foreign key, then re-running, now reports \`Nothing is modified\` (previously looped forever trying to add the FK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)