### PR TITLE
Switch integration tests to Spanner Omni

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,60 +6,54 @@ on:
       - "**"
 
 jobs:
-  test:
+  test-omni:
+    name: Tests (Spanner Omni)
     runs-on: ubuntu-latest
-
-    services:
-      spanner-emulator:
-        image: gcr.io/cloud-spanner-emulator/emulator:1.5.34
-        ports:
-          - 9010:9010
-          - 9020:9020
+    timeout-minutes: 20
 
     steps:
     - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
-        go-version: '1.21'
+        go-version-file: go.mod
 
-    - name: Install gcloud CLI (for Spanner client)
-      uses: google-github-actions/setup-gcloud@v1
-      with:
-        version: 'latest'
-
-    - name: Wait for Spanner emulator to be ready
+    - name: Start Spanner Omni
+      # Omni's single-server mode uses project=default, instance=default
+      # and listens on gRPC 15000. --network host isn't reliable on GitHub
+      # Actions Linux runners, so publish the port explicitly.
       run: |
-        timeout 60 bash -c 'until nc -z localhost 9010; do sleep 1; done'
-        timeout 60 bash -c 'until nc -z localhost 9020; do sleep 1; done'
-        echo "Spanner emulator is ready"
+        docker run -d \
+          --name spanneromni \
+          -p 15000:15000 \
+          -v spanner:/spanner \
+          us-docker.pkg.dev/spanner-omni/images/spanner-omni:2026.r1-beta \
+          start-single-server
 
-    - name: Create Spanner instance and database
-      env:
-        CLOUDSDK_API_ENDPOINT_OVERRIDES_SPANNER: http://localhost:9020/
-        SPANNER_EMULATOR_HOST: localhost:9010
-        SPANNER_EMULATOR_HOST_REST: localhost:9020
-        CLOUDSDK_CORE_PROJECT: test-project
-        CLOUDSDK_AUTH_DISABLE_CREDENTIALS: true
+    - name: Wait for Spanner Omni to be ready
       run: |
-        # Set default project for emulator
-        gcloud config set project test-project
-        gcloud config set auth/disable_credentials true
-        gcloud config set api_endpoint_overrides/spanner http://localhost:9020/
-
-        # Create instance
-        gcloud spanner instances create test-instance \
-          --config=emulator-config \
-          --description="Test instance" \
-          --nodes=1
-
-        # Create database
-        gcloud spanner databases create test-database \
-          --instance=test-instance
+        for i in $(seq 1 90); do
+          if docker logs spanneromni 2>&1 | grep -q "Spanner is ready"; then
+            echo "Spanner Omni is ready"
+            exit 0
+          fi
+          sleep 2
+        done
+        echo "Spanner Omni failed to become ready"
+        docker logs spanneromni
+        exit 1
 
     - name: Download dependencies
       run: go mod download
 
-    - name: Run unit tests
-      run: go test -v ./...
+    - name: Run tests
+      env:
+        SPANNER_EMULATOR_HOST: localhost:15000
+        SPANNER_PROJECT_ID: default
+        SPANNER_INSTANCE_ID: default
+      run: go test -v -count=1 -timeout 15m -parallel 80 ./...
+
+    - name: Dump Omni logs on failure
+      if: failure()
+      run: docker logs spanneromni || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,8 @@ on:
       - "**"
 
 jobs:
-  test-omni:
-    name: Tests (Spanner Omni)
+  test:
+    name: Tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
 

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,52 @@
-.PHONY: build test clean help
+.PHONY: build test omni-up omni-down clean help
+
+# Spanner Omni single-server defaults
+OMNI_HOST      ?= localhost:15000
+OMNI_PROJECT   ?= default
+OMNI_INSTANCE  ?= default
+OMNI_IMAGE     ?= us-docker.pkg.dev/spanner-omni/images/spanner-omni:2026.r1-beta
+OMNI_CONTAINER ?= spanneromni
+
+# -parallel 80 empirically minimises wall time against Omni single-server
+# on an 8-core laptop (~80s vs ~150s at -parallel 10). Going higher starts
+# to hurt as Omni serializes CREATE DATABASE internally.
+TEST_PARALLEL ?= 80
 
 build:
 	go build -o bin/spannerdef ./cmd/spannerdef
 
+# Run tests against Spanner Omni (start it with `make omni-up` first).
+# -count=1 disables Go's test cache — integration tests depend on the live
+# Omni server so we always want them to actually run.
 test:
-	go test -v ./...
+	SPANNER_EMULATOR_HOST=$(OMNI_HOST) \
+	SPANNER_PROJECT_ID=$(OMNI_PROJECT) \
+	SPANNER_INSTANCE_ID=$(OMNI_INSTANCE) \
+	go test -v -count=1 -timeout 15m -parallel $(TEST_PARALLEL) ./...
+
+omni-up:
+	docker run -d --network host --name $(OMNI_CONTAINER) \
+		-v spanner:/spanner $(OMNI_IMAGE) start-single-server
+	@echo "Waiting for Spanner Omni to be ready..."
+	@until docker logs $(OMNI_CONTAINER) 2>&1 | grep -q "Spanner is ready"; do sleep 2; done
+	@echo "Spanner Omni is ready on $(OMNI_HOST)"
+
+omni-down:
+	-docker rm -f $(OMNI_CONTAINER)
+	-docker volume rm spanner
 
 clean:
 	rm -rf bin/
 
 help:
 	@echo "Available targets:"
-	@echo "  build        - Build spannerdef binary"
-	@echo "  test         - Run all tests (requires emulator for some tests)"
-	@echo "  clean        - Clean build artifacts"
-	@echo "  help         - Show this help message"
+	@echo "  build      - Build spannerdef binary"
+	@echo "  test       - Run tests against Spanner Omni"
+	@echo "  omni-up    - Start Spanner Omni container"
+	@echo "  omni-down  - Stop Spanner Omni and clear its volume"
+	@echo "  clean      - Clean build artifacts"
+	@echo "  help       - Show this help message"
 	@echo ""
-	@echo "To run tests with Spanner emulator:"
-	@echo "  docker-compose up -d  # Start emulator"
-	@echo "  make test             # Run all tests"
+	@echo "To run tests with Spanner Omni:"
+	@echo "  make omni-up   # Start Omni"
+	@echo "  make test      # Run tests"

--- a/README.md
+++ b/README.md
@@ -145,19 +145,22 @@ go build ./cmd/spannerdef
 
 ### Testing
 
-spannerdef includes comprehensive tests that use Spanner emulator.
+spannerdef's integration tests run against [Spanner Omni](https://cloud.google.com/spanner-omni/docs) — the offline single-server distribution of Spanner. Omni matches production DDL semantics (e.g. foreign keys dumped as `ALTER TABLE ADD CONSTRAINT`), which the Emulator does not.
 
-**Requirements**: Docker/Docker Compose for Spanner emulator.
+**Requirements**: Docker.
 
 ```bash
-# Start Spanner emulator
-docker-compose up
+# Start Spanner Omni
+make omni-up
 
 # Run all tests
 make test
 
 # Run specific tests
 go test -v . -run TestBasicOperations
+
+# Stop Spanner Omni and clear its volume
+make omni-down
 ```
 
 ## Limitations

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,0 @@
-services:
-  spanner-emulator:
-    image: gcr.io/cloud-spanner-emulator/emulator:1.5.0
-    ports:
-      - "9010:9010"  # gRPC port
-      - "9020:9020"  # REST port
-    environment:
-      - SPANNER_EMULATOR_HOST=0.0.0.0:9010

--- a/spanner_test.go
+++ b/spanner_test.go
@@ -9,45 +9,34 @@ import (
 	"time"
 
 	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
-	instanceadmin "cloud.google.com/go/spanner/admin/instance/apiv1"
-	"cloud.google.com/go/spanner/admin/instance/apiv1/instancepb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
-// getTestConfig returns the test database configuration for Spanner emulator
+// getTestConfig returns the base Config used by every integration test.
+// SPANNER_EMULATOR_HOST must point at a Spanner Omni gRPC endpoint; each
+// individual test creates its own database via newTestDatabase.
 func getTestConfig(t *testing.T) Config {
 	t.Helper()
 
-	// Check if running against Spanner emulator
-	emulatorHost := getEnvOrDefault("SPANNER_EMULATOR_HOST", "localhost:9010")
-
-	// Verify emulator is actually running by checking if host is reachable
-	if !isEmulatorRunning(emulatorHost) {
-		t.Skip("Spanner emulator tests require emulator. Please start it with: docker-compose up -d")
+	host := os.Getenv("SPANNER_EMULATOR_HOST")
+	if host == "" {
+		t.Skip("SPANNER_EMULATOR_HOST not set; run `make omni-up && make test`")
 	}
 
-	// Set up environment variables for emulator
-	setupEmulatorEnvironment(emulatorHost)
-
-	// Default values for emulator
-	projectID := getEnvOrDefault("SPANNER_PROJECT_ID", "test-project")
-	instanceID := getEnvOrDefault("SPANNER_INSTANCE_ID", "test-instance")
-	databaseID := getEnvOrDefault("SPANNER_DATABASE_ID", "test-database")
-
-	// Ensure instance and database exist
-	ensureInstanceAndDatabase(t, projectID, instanceID, databaseID)
+	if !isOmniRunning(host) {
+		t.Skip("Spanner Omni not reachable at " + host + "; run `make omni-up`")
+	}
 
 	return Config{
-		ProjectID:  projectID,
-		InstanceID: instanceID,
-		DatabaseID: databaseID,
+		ProjectID:  getEnvOrDefault("SPANNER_PROJECT_ID", "default"),
+		InstanceID: getEnvOrDefault("SPANNER_INSTANCE_ID", "default"),
+		DatabaseID: getEnvOrDefault("SPANNER_DATABASE_ID", "testdb"),
 	}
 }
 
-// getEnvOrDefault returns the environment variable value or a default value
 func getEnvOrDefault(envVar, defaultValue string) string {
 	if value := os.Getenv(envVar); value != "" {
 		return value
@@ -55,114 +44,13 @@ func getEnvOrDefault(envVar, defaultValue string) string {
 	return defaultValue
 }
 
-// isEmulatorRunning checks if Spanner emulator is running on the given host
-func isEmulatorRunning(host string) bool {
+func isOmniRunning(host string) bool {
 	conn, err := net.DialTimeout("tcp", host, 1*time.Second)
 	if err != nil {
 		return false
 	}
 	conn.Close()
 	return true
-}
-
-// setupEmulatorEnvironment sets up environment variables for emulator
-func setupEmulatorEnvironment(emulatorHost string) {
-	// Set SPANNER_EMULATOR_HOST if not already set
-	if os.Getenv("SPANNER_EMULATOR_HOST") == "" {
-		os.Setenv("SPANNER_EMULATOR_HOST", emulatorHost)
-	}
-
-	// Set other emulator-related environment variables
-	if os.Getenv("CLOUDSDK_API_ENDPOINT_OVERRIDES_SPANNER") == "" {
-		os.Setenv("CLOUDSDK_API_ENDPOINT_OVERRIDES_SPANNER", "http://localhost:9020/")
-	}
-	if os.Getenv("SPANNER_EMULATOR_HOST_REST") == "" {
-		os.Setenv("SPANNER_EMULATOR_HOST_REST", "localhost:9020")
-	}
-	if os.Getenv("CLOUDSDK_CORE_PROJECT") == "" {
-		os.Setenv("CLOUDSDK_CORE_PROJECT", "test-project")
-	}
-	if os.Getenv("CLOUDSDK_AUTH_DISABLE_CREDENTIALS") == "" {
-		os.Setenv("CLOUDSDK_AUTH_DISABLE_CREDENTIALS", "true")
-	}
-}
-
-// ensureInstanceAndDatabase creates instance and database if they don't exist
-func ensureInstanceAndDatabase(t *testing.T, projectID, instanceID, databaseID string) {
-	t.Helper()
-
-	ctx := context.Background()
-
-	// Create instance if it doesn't exist
-	if !instanceExists(t, ctx, projectID, instanceID) {
-		createInstance(t, ctx, projectID, instanceID)
-	}
-
-	// Create database if it doesn't exist
-	if !databaseExists(t, ctx, projectID, instanceID, databaseID) {
-		createDatabase(t, ctx, projectID, instanceID, databaseID)
-	}
-}
-
-// Test-only helper functions for instance management
-func createInstanceAdminClient(ctx context.Context) (*instanceadmin.InstanceAdminClient, error) {
-	return instanceadmin.NewInstanceAdminClient(ctx)
-}
-
-// Helper functions for instance and database management (test-only)
-func instanceExists(t *testing.T, ctx context.Context, projectID, instanceID string) bool {
-	t.Helper()
-
-	instanceAdminClient, err := createInstanceAdminClient(ctx)
-	if err != nil {
-		t.Logf("Failed to create instance admin client: %v", err)
-		return false
-	}
-	defer instanceAdminClient.Close()
-
-	instancePath := "projects/" + projectID + "/instances/" + instanceID
-	_, err = instanceAdminClient.GetInstance(ctx, &instancepb.GetInstanceRequest{
-		Name: instancePath,
-	})
-	if err != nil {
-		if status.Code(err) == codes.NotFound {
-			t.Logf("Instance %s does not exist", instanceID)
-			return false
-		}
-		t.Logf("Error checking instance existence: %v", err)
-		return false
-	}
-	t.Logf("Instance %s exists", instanceID)
-	return true
-}
-
-func createInstance(t *testing.T, ctx context.Context, projectID, instanceID string) {
-	t.Helper()
-
-	t.Logf("Creating Spanner instance: %s", instanceID)
-
-	instanceAdminClient, err := createInstanceAdminClient(ctx)
-	require.NoError(t, err)
-	defer instanceAdminClient.Close()
-
-	instancePath := "projects/" + projectID + "/instances/" + instanceID
-	parentPath := "projects/" + projectID
-
-	op, err := instanceAdminClient.CreateInstance(ctx, &instancepb.CreateInstanceRequest{
-		Parent:     parentPath,
-		InstanceId: instanceID,
-		Instance: &instancepb.Instance{
-			Name:        instancePath,
-			Config:      "projects/" + projectID + "/instanceConfigs/emulator-config",
-			DisplayName: "Test instance for integration tests",
-			NodeCount:   1,
-		},
-	})
-	require.NoError(t, err)
-	_, err = op.Wait(ctx)
-	require.NoError(t, err)
-
-	t.Logf("Instance %s created successfully", instanceID)
 }
 
 func databaseExists(t *testing.T, ctx context.Context, projectID, instanceID, databaseID string) bool {
@@ -174,7 +62,6 @@ func databaseExists(t *testing.T, ctx context.Context, projectID, instanceID, da
 		DatabaseID: databaseID,
 	})
 	if err != nil {
-		t.Logf("Failed to create admin client: %v", err)
 		return false
 	}
 	defer adminDB.Close()
@@ -185,107 +72,65 @@ func databaseExists(t *testing.T, ctx context.Context, projectID, instanceID, da
 	})
 	if err != nil {
 		if status.Code(err) == codes.NotFound {
-			t.Logf("Database %s does not exist", databaseID)
 			return false
 		}
-		t.Logf("Error checking database existence: %v", err)
 		return false
 	}
-	t.Logf("Database %s exists", databaseID)
 	return true
 }
 
-func createDatabase(t *testing.T, ctx context.Context, projectID, instanceID, databaseID string) {
-	t.Helper()
-
-	t.Logf("Creating Spanner database: %s", databaseID)
-
-	adminDB, err := NewAdminDatabase(Config{
-		ProjectID:  projectID,
-		InstanceID: instanceID,
-		DatabaseID: databaseID,
-	})
-	require.NoError(t, err)
-	defer adminDB.Close()
-
-	instancePath := "projects/" + projectID + "/instances/" + instanceID
-	createStatement := "CREATE DATABASE `" + databaseID + "`"
-
-	op, err := adminDB.DatabaseAdminClient().CreateDatabase(ctx, &databasepb.CreateDatabaseRequest{
-		Parent:          instancePath,
-		CreateStatement: createStatement,
-	})
-	require.NoError(t, err)
-	_, err = op.Wait(ctx)
-	require.NoError(t, err)
-
-	t.Logf("Database %s created successfully", databaseID)
-}
-
 func TestNewDatabase(t *testing.T) {
+	t.Parallel()
 	config := getTestConfig(t)
 
-	db, err := NewDatabase(config)
-	require.NoError(t, err)
+	db, _ := newTestDatabase(t, config)
 	assert.NotNil(t, db)
 	assert.Equal(t, config.ProjectID, db.projectID)
 	assert.Equal(t, config.InstanceID, db.instanceID)
-	assert.Equal(t, config.DatabaseID, db.databaseID)
-
-	err = db.Close()
-	assert.NoError(t, err)
 }
 
 func TestSpannerDatabase_DumpDDLs(t *testing.T) {
+	t.Parallel()
 	config := getTestConfig(t)
 
-	db, err := NewDatabase(config)
-	require.NoError(t, err)
-	defer db.Close()
+	db, _ := newTestDatabase(t, config)
 
-	// Test dumping empty database
 	ddls, err := db.DumpDDLs()
 	require.NoError(t, err)
-	// Empty database should return empty string or just semicolon
+	// Empty database returns either "" or ";".
 	trimmed := strings.TrimSpace(strings.Trim(ddls, ";"))
 	assert.Empty(t, trimmed)
 }
 
 func TestSpannerDatabase_ExecDDL(t *testing.T) {
+	t.Parallel()
 	config := getTestConfig(t)
 
-	db, err := NewDatabase(config)
-	require.NoError(t, err)
-	defer db.Close()
+	db, _ := newTestDatabase(t, config)
 
-	// Create a test table
 	ddl := `CREATE TABLE TestTable (
 		Id INT64 NOT NULL,
 		Name STRING(100)
 	) PRIMARY KEY (Id)`
 
-	err = db.ExecDDL(ddl)
+	err := db.ExecDDL(ddl)
 	require.NoError(t, err)
 
-	// Verify table was created
 	ddls, err := db.DumpDDLs()
 	require.NoError(t, err)
 	assert.Contains(t, ddls, "TestTable")
 	assert.Contains(t, ddls, "STRING(100)")
 
-	// Clean up
 	err = db.ExecDDL("DROP TABLE TestTable")
 	require.NoError(t, err)
 }
 
 func TestSpannerDatabase_ExecDDLs(t *testing.T) {
+	t.Parallel()
 	config := getTestConfig(t)
 
-	db, err := NewDatabase(config)
-	require.NoError(t, err)
-	defer db.Close()
+	db, _ := newTestDatabase(t, config)
 
-	// Create multiple DDLs
 	ddls := []string{
 		`CREATE TABLE Users (
 			Id INT64 NOT NULL,
@@ -297,25 +142,17 @@ func TestSpannerDatabase_ExecDDLs(t *testing.T) {
 		) PRIMARY KEY (Id)`,
 	}
 
-	err = db.ExecDDLs(ddls)
+	err := db.ExecDDLs(ddls)
 	require.NoError(t, err)
 
-	// Verify tables were created
 	resultDDLs, err := db.DumpDDLs()
 	require.NoError(t, err)
 	assert.Contains(t, resultDDLs, "Users")
 	assert.Contains(t, resultDDLs, "Posts")
-
-	// Clean up
-	cleanupDDLs := []string{
-		"DROP TABLE Users",
-		"DROP TABLE Posts",
-	}
-	err = db.ExecDDLs(cleanupDDLs)
-	require.NoError(t, err)
 }
 
 func TestNewAdminDatabase(t *testing.T) {
+	t.Parallel()
 	config := getTestConfig(t)
 
 	adminDB, err := NewAdminDatabase(config)
@@ -325,18 +162,15 @@ func TestNewAdminDatabase(t *testing.T) {
 	assert.Equal(t, config.InstanceID, adminDB.instanceID)
 	assert.Equal(t, config.DatabaseID, adminDB.databaseID)
 
-	// Test that admin database was created successfully
-	assert.NotNil(t, adminDB)
-
 	err = adminDB.Close()
 	assert.NoError(t, err)
 }
 
 func TestSpannerAdminDatabase_DatabaseLifecycle(t *testing.T) {
+	t.Parallel()
 	config := getTestConfig(t)
 
-	// Use a unique database name for this test
-	config.DatabaseID = "test-lifecycle-db"
+	config.DatabaseID = uniqueDatabaseID()
 
 	adminDB, err := NewAdminDatabase(config)
 	require.NoError(t, err)
@@ -344,56 +178,34 @@ func TestSpannerAdminDatabase_DatabaseLifecycle(t *testing.T) {
 
 	ctx := context.Background()
 
-	// Create database
-	err = adminDB.CreateDatabase(ctx)
+	// Use the same fast-polling path the other test helpers use so the
+	// lifecycle test doesn't sit on the generated client's 1-minute poll.
+	op, err := adminDB.DatabaseAdminClient().CreateDatabase(ctx, &databasepb.CreateDatabaseRequest{
+		Parent:          "projects/" + config.ProjectID + "/instances/" + config.InstanceID,
+		CreateStatement: "CREATE DATABASE `" + config.DatabaseID + "`",
+	})
 	require.NoError(t, err)
+	require.NoError(t, waitCreateDBOp(ctx, op))
 
-	// Verify database exists by trying to connect to it
 	db, err := NewDatabase(config)
 	require.NoError(t, err)
-
-	// Test basic operation
-	ddls, err := db.DumpDDLs()
+	_, err = db.DumpDDLs()
 	require.NoError(t, err)
-	_ = ddls // Database should be accessible
-
 	db.Close()
 
-	// Drop database
 	err = adminDB.DropDatabase(ctx)
 	require.NoError(t, err)
 
-	// Verify database no longer exists by checking with admin client
-	// Note: In emulator, connection might still work briefly after drop
 	exists := databaseExists(t, ctx, config.ProjectID, config.InstanceID, config.DatabaseID)
 	assert.False(t, exists, "Database should not exist after drop")
 }
 
 func TestSpannerDatabase_RowDeletionPolicy(t *testing.T) {
+	t.Parallel()
 	config := getTestConfig(t)
 
-	// Create admin database to ensure clean state
-	adminDB, err := NewAdminDatabase(config)
-	require.NoError(t, err)
-	defer adminDB.Close()
+	db := recreateDatabase(t, config)
 
-	ctx := context.Background()
-
-	// Drop and recreate database
-	err = adminDB.DropDatabase(ctx)
-	if err != nil && !strings.Contains(err.Error(), "not found") {
-		t.Logf("Warning: Could not drop database: %v", err)
-	}
-
-	err = adminDB.CreateDatabase(ctx)
-	require.NoError(t, err)
-
-	// Test with regular database connection
-	db, err := NewDatabase(config)
-	require.NoError(t, err)
-	defer db.Close()
-
-	// Create table with ROW DELETION POLICY
 	ddl := `CREATE TABLE events (
 		id INT64 NOT NULL,
 		name STRING(100),
@@ -401,45 +213,20 @@ func TestSpannerDatabase_RowDeletionPolicy(t *testing.T) {
 	) PRIMARY KEY (id),
 	ROW DELETION POLICY (OLDER_THAN(event_date, INTERVAL 30 DAY))`
 
-	err = db.ExecDDL(ddl)
-	require.NoError(t, err)
+	require.NoError(t, execDDLsFast(context.Background(), db.adminClient, db.databasePath, []string{ddl}))
 
-	// Dump DDLs and verify ROW DELETION POLICY is preserved
 	dumpedDDLs, err := db.DumpDDLs()
 	require.NoError(t, err)
 	assert.Contains(t, dumpedDDLs, "ROW DELETION POLICY")
 	assert.Contains(t, dumpedDDLs, "OLDER_THAN(event_date, INTERVAL 30 DAY)")
-
-	// Clean up
-	err = adminDB.DropDatabase(ctx)
-	require.NoError(t, err)
 }
 
 func TestSpannerDatabase_RowDeletionPolicyWithInterleave(t *testing.T) {
+	t.Parallel()
 	config := getTestConfig(t)
 
-	// Create admin database to ensure clean state
-	adminDB, err := NewAdminDatabase(config)
-	require.NoError(t, err)
-	defer adminDB.Close()
+	db := recreateDatabase(t, config)
 
-	ctx := context.Background()
-
-	// Drop and recreate database
-	err = adminDB.DropDatabase(ctx)
-	if err != nil && !strings.Contains(err.Error(), "not found") {
-		t.Logf("Warning: Could not drop database: %v", err)
-	}
-
-	err = adminDB.CreateDatabase(ctx)
-	require.NoError(t, err)
-
-	// Test with regular database connection
-	db, err := NewDatabase(config)
-	require.NoError(t, err)
-	defer db.Close()
-
-	// Create parent and child tables with ROW DELETION POLICY
 	ddls := []string{
 		`CREATE TABLE users (
 			id INT64 NOT NULL
@@ -453,19 +240,12 @@ func TestSpannerDatabase_RowDeletionPolicyWithInterleave(t *testing.T) {
 		ROW DELETION POLICY (OLDER_THAN(event_date, INTERVAL 90 DAY))`,
 	}
 
-	err = db.ExecDDLs(ddls)
-	require.NoError(t, err)
+	require.NoError(t, execDDLsFast(context.Background(), db.adminClient, db.databasePath, ddls))
 
-	// Dump DDLs and verify both INTERLEAVE and ROW DELETION POLICY are preserved
 	dumpedDDLs, err := db.DumpDDLs()
 	require.NoError(t, err)
 
-	// Check that events table has both features
 	assert.Contains(t, dumpedDDLs, "INTERLEAVE IN PARENT users")
 	assert.Contains(t, dumpedDDLs, "ROW DELETION POLICY")
 	assert.Contains(t, dumpedDDLs, "OLDER_THAN(event_date, INTERVAL 90 DAY)")
-
-	// Clean up
-	err = adminDB.DropDatabase(ctx)
-	require.NoError(t, err)
 }

--- a/spannerdef_test.go
+++ b/spannerdef_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,49 +17,45 @@ type TestCase struct {
 	Expected string // Expected DDL output (empty means no changes expected)
 }
 
-// recreateDatabase drops and recreates the test database for a clean state
-func recreateDatabase(t *testing.T, config Config) Database {
-	// For emulator, we can recreate the database for each test
-	adminDB, err := NewAdminDatabase(config)
-	require.NoError(t, err)
-	defer adminDB.Close()
-
-	// Drop and recreate database
-	ctx := context.Background()
-	err = adminDB.DropDatabase(ctx)
-	if err != nil && !strings.Contains(err.Error(), "not found") {
-		t.Logf("Warning: Could not drop database: %v", err)
-	}
-
-	err = adminDB.CreateDatabase(ctx)
-	require.NoError(t, err, "Failed to create test database")
-
-	// Wait a moment for database to be ready
-	time.Sleep(100 * time.Millisecond)
-
-	// Return regular database connection
-	db, err := NewDatabase(config)
-	require.NoError(t, err)
+// recreateDatabase returns a freshly-created database dedicated to this test.
+// Each caller gets its own Spanner database so the test suite can run in
+// parallel against Omni without stepping on shared schema.
+func recreateDatabase(t *testing.T, config Config) *SpannerDatabase {
+	t.Helper()
+	db, _ := newTestDatabase(t, config)
 	return db
 }
 
-// applySchema applies the given schema and returns the generated DDLs
-func applySchema(t *testing.T, db Database, schema string, enableDrop bool) []string {
+// applySchema computes the DDL diff and applies it through the admin client
+// with a short polling interval. It intentionally bypasses SpannerDatabase's
+// own ExecDDLs path (which waits on the generated client's 1-minute LRO
+// polling interval) because setup DDLs are not what we're testing.
+func applySchema(t *testing.T, db *SpannerDatabase, schema string, enableDrop bool) []string {
 	t.Helper()
 
-	// Generate DDLs
 	currentDDLs, err := db.DumpDDLs()
 	require.NoError(t, err)
 
 	ddls, err := GenerateIdempotentDDLs(schema, currentDDLs, GeneratorConfig{})
 	require.NoError(t, err)
 
-	// Apply the DDLs
-	if len(ddls) > 0 {
-		err = RunDDLs(db, ddls, enableDrop, true)
-		require.NoError(t, err)
+	if len(ddls) == 0 {
+		return ddls
 	}
 
+	valid := make([]string, 0, len(ddls))
+	for _, ddl := range ddls {
+		if !enableDrop && (strings.Contains(ddl, "DROP TABLE") ||
+			strings.Contains(ddl, "DROP INDEX") ||
+			strings.Contains(ddl, "DROP COLUMN")) {
+			continue
+		}
+		valid = append(valid, ddl)
+	}
+
+	if len(valid) > 0 {
+		require.NoError(t, execDDLsFast(context.Background(), db.adminClient, db.databasePath, valid))
+	}
 	return ddls
 }
 
@@ -87,9 +82,11 @@ func assertDDLNotContains(t *testing.T, ddls []string, pattern string) {
 
 // TestBasicOperations tests basic DDL operations
 func TestBasicOperations(t *testing.T) {
+	t.Parallel()
 	config := getTestConfig(t)
 
 	t.Run("CreateTable", func(t *testing.T) {
+		t.Parallel()
 		db := recreateDatabase(t, config)
 		defer db.Close()
 
@@ -115,6 +112,7 @@ func TestBasicOperations(t *testing.T) {
 	})
 
 	t.Run("AddColumn", func(t *testing.T) {
+		t.Parallel()
 		db := recreateDatabase(t, config)
 		defer db.Close()
 
@@ -143,6 +141,7 @@ func TestBasicOperations(t *testing.T) {
 	})
 
 	t.Run("DropColumn", func(t *testing.T) {
+		t.Parallel()
 		db := recreateDatabase(t, config)
 		defer db.Close()
 
@@ -171,6 +170,7 @@ func TestBasicOperations(t *testing.T) {
 	})
 
 	t.Run("CreateIndex", func(t *testing.T) {
+		t.Parallel()
 		db := recreateDatabase(t, config)
 		defer db.Close()
 
@@ -192,6 +192,7 @@ func TestBasicOperations(t *testing.T) {
 	})
 
 	t.Run("DropIndex", func(t *testing.T) {
+		t.Parallel()
 		db := recreateDatabase(t, config)
 		defer db.Close()
 
@@ -225,6 +226,7 @@ func TestBasicOperations(t *testing.T) {
 	})
 
 	t.Run("DropTable", func(t *testing.T) {
+		t.Parallel()
 		db := recreateDatabase(t, config)
 		defer db.Close()
 
@@ -258,9 +260,11 @@ func TestBasicOperations(t *testing.T) {
 
 // TestSpannerSpecificFeatures tests Spanner-specific DDL features
 func TestSpannerSpecificFeatures(t *testing.T) {
+	t.Parallel()
 	config := getTestConfig(t)
 
 	t.Run("ArrayColumns", func(t *testing.T) {
+		t.Parallel()
 		db := recreateDatabase(t, config)
 		defer db.Close()
 
@@ -284,6 +288,7 @@ func TestSpannerSpecificFeatures(t *testing.T) {
 	})
 
 	t.Run("CommitTimestamp", func(t *testing.T) {
+		t.Parallel()
 		db := recreateDatabase(t, config)
 		defer db.Close()
 
@@ -303,6 +308,7 @@ func TestSpannerSpecificFeatures(t *testing.T) {
 	})
 
 	t.Run("IndexWithStoring", func(t *testing.T) {
+		t.Parallel()
 		db := recreateDatabase(t, config)
 		defer db.Close()
 
@@ -327,6 +333,7 @@ func TestSpannerSpecificFeatures(t *testing.T) {
 	})
 
 	t.Run("InterleavedTables", func(t *testing.T) {
+		t.Parallel()
 		db := recreateDatabase(t, config)
 		defer db.Close()
 
@@ -353,6 +360,7 @@ func TestSpannerSpecificFeatures(t *testing.T) {
 	})
 
 	t.Run("InterleavedTablesOrder", func(t *testing.T) {
+		t.Parallel()
 		db := recreateDatabase(t, config)
 		defer db.Close()
 
@@ -395,6 +403,7 @@ func TestSpannerSpecificFeatures(t *testing.T) {
 	})
 
 	t.Run("ColumnOrdering", func(t *testing.T) {
+		t.Parallel()
 		db := recreateDatabase(t, config)
 		defer db.Close()
 
@@ -431,6 +440,7 @@ func TestSpannerSpecificFeatures(t *testing.T) {
 	})
 
 	t.Run("DefaultClauseSupport", func(t *testing.T) {
+		t.Parallel()
 		db := recreateDatabase(t, config)
 		defer db.Close()
 
@@ -452,6 +462,7 @@ func TestSpannerSpecificFeatures(t *testing.T) {
 	})
 
 	t.Run("ColumnTypeChange", func(t *testing.T) {
+		t.Parallel()
 		db := recreateDatabase(t, config)
 		defer db.Close()
 
@@ -477,6 +488,7 @@ func TestSpannerSpecificFeatures(t *testing.T) {
 	})
 
 	t.Run("CheckConstraints", func(t *testing.T) {
+		t.Parallel()
 		db := recreateDatabase(t, config)
 		defer db.Close()
 
@@ -502,6 +514,7 @@ func TestSpannerSpecificFeatures(t *testing.T) {
 	})
 
 	t.Run("AddCheckConstraint", func(t *testing.T) {
+		t.Parallel()
 		db := recreateDatabase(t, config)
 		defer db.Close()
 
@@ -530,6 +543,7 @@ func TestSpannerSpecificFeatures(t *testing.T) {
 	})
 
 	t.Run("DropCheckConstraint", func(t *testing.T) {
+		t.Parallel()
 		db := recreateDatabase(t, config)
 		defer db.Close()
 
@@ -558,6 +572,7 @@ func TestSpannerSpecificFeatures(t *testing.T) {
 	})
 
 	t.Run("ModifyCheckConstraint", func(t *testing.T) {
+		t.Parallel()
 		db := recreateDatabase(t, config)
 		defer db.Close()
 
@@ -589,6 +604,7 @@ func TestSpannerSpecificFeatures(t *testing.T) {
 	})
 
 	t.Run("MultipleCheckConstraints", func(t *testing.T) {
+		t.Parallel()
 		db := recreateDatabase(t, config)
 		defer db.Close()
 
@@ -617,6 +633,7 @@ func TestSpannerSpecificFeatures(t *testing.T) {
 	})
 
 	t.Run("ForeignKeyConstraints", func(t *testing.T) {
+		t.Parallel()
 		db := recreateDatabase(t, config)
 		defer db.Close()
 
@@ -647,6 +664,7 @@ func TestSpannerSpecificFeatures(t *testing.T) {
 	})
 
 	t.Run("AddForeignKeyConstraint", func(t *testing.T) {
+		t.Parallel()
 		db := recreateDatabase(t, config)
 		defer db.Close()
 
@@ -685,6 +703,7 @@ func TestSpannerSpecificFeatures(t *testing.T) {
 	})
 
 	t.Run("DropForeignKeyConstraint", func(t *testing.T) {
+		t.Parallel()
 		db := recreateDatabase(t, config)
 		defer db.Close()
 
@@ -723,6 +742,7 @@ func TestSpannerSpecificFeatures(t *testing.T) {
 	})
 
 	t.Run("ForeignKeyWithMultipleColumns", func(t *testing.T) {
+		t.Parallel()
 		db := recreateDatabase(t, config)
 		defer db.Close()
 
@@ -755,15 +775,18 @@ func TestSpannerSpecificFeatures(t *testing.T) {
 	// Skipping this test as Spanner doesn't support ON DELETE in FOREIGN KEY constraints
 	// within CREATE TABLE statements. ON DELETE is only supported for INTERLEAVE relationships.
 	t.Run("ForeignKeyWithOnDelete", func(t *testing.T) {
+		t.Parallel()
 		t.Skip("Spanner doesn't support ON DELETE in FOREIGN KEY constraints")
 	})
 }
 
 // TestEdgeCases tests edge cases and error conditions
 func TestEdgeCases(t *testing.T) {
+	t.Parallel()
 	config := getTestConfig(t)
 
 	t.Run("EmptySchema", func(t *testing.T) {
+		t.Parallel()
 		db := recreateDatabase(t, config)
 		defer db.Close()
 
@@ -772,6 +795,7 @@ func TestEdgeCases(t *testing.T) {
 	})
 
 	t.Run("NoChanges", func(t *testing.T) {
+		t.Parallel()
 		db := recreateDatabase(t, config)
 		defer db.Close()
 
@@ -789,6 +813,7 @@ func TestEdgeCases(t *testing.T) {
 	})
 
 	t.Run("DropWithoutEnableDrop", func(t *testing.T) {
+		t.Parallel()
 		db := recreateDatabase(t, config)
 		defer db.Close()
 
@@ -831,6 +856,7 @@ func TestEdgeCases(t *testing.T) {
 	})
 
 	t.Run("ComplexColumnTypes", func(t *testing.T) {
+		t.Parallel()
 		db := recreateDatabase(t, config)
 		defer db.Close()
 
@@ -863,9 +889,11 @@ func TestEdgeCases(t *testing.T) {
 
 // TestConcurrentOperations tests behavior with multiple tables and indexes
 func TestConcurrentOperations(t *testing.T) {
+	t.Parallel()
 	config := getTestConfig(t)
 
 	t.Run("MultipleTablesAndIndexes", func(t *testing.T) {
+		t.Parallel()
 		db := recreateDatabase(t, config)
 		defer db.Close()
 
@@ -912,9 +940,11 @@ func TestConcurrentOperations(t *testing.T) {
 
 // TestExport tests the export functionality
 func TestExport(t *testing.T) {
+	t.Parallel()
 	config := getTestConfig(t)
 
 	t.Run("ExportEmptyDatabase", func(t *testing.T) {
+		t.Parallel()
 		db := recreateDatabase(t, config)
 		defer db.Close()
 
@@ -926,6 +956,7 @@ func TestExport(t *testing.T) {
 	})
 
 	t.Run("ExportWithTables", func(t *testing.T) {
+		t.Parallel()
 		db := recreateDatabase(t, config)
 		defer db.Close()
 
@@ -949,9 +980,11 @@ func TestExport(t *testing.T) {
 
 // TestConfigFiltering tests table filtering functionality
 func TestConfigFiltering(t *testing.T) {
+	t.Parallel()
 	config := getTestConfig(t)
 
 	t.Run("TargetTables", func(t *testing.T) {
+		t.Parallel()
 		db := recreateDatabase(t, config)
 		defer db.Close()
 
@@ -987,6 +1020,7 @@ func TestConfigFiltering(t *testing.T) {
 	})
 
 	t.Run("SkipTables", func(t *testing.T) {
+		t.Parallel()
 		db := recreateDatabase(t, config)
 		defer db.Close()
 

--- a/testutil_test.go
+++ b/testutil_test.go
@@ -1,0 +1,146 @@
+package spannerdef
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	dbadmin "cloud.google.com/go/spanner/admin/database/apiv1"
+	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
+	gax "github.com/googleapis/gax-go/v2"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+)
+
+// Test-only fast-polling helpers. The generated LRO op.Wait() uses a 1-minute
+// polling interval, which is fine against production Spanner but makes tests
+// against Spanner Omni (where each DDL batch completes in ~tens of seconds)
+// wait roughly a minute per operation. We keep this behaviour out of
+// production code and let tests drive their own polling.
+
+const ddlPollInterval = 1 * time.Second
+
+// pollCallOptions extend the per-request polling call. The default
+// GetOperation timeout is 10s with retries only on Unavailable, which
+// occasionally surfaces DeadlineExceeded while Omni is busy.
+func pollCallOptions() []gax.CallOption {
+	return []gax.CallOption{
+		gax.WithTimeout(60 * time.Second),
+		gax.WithRetry(func() gax.Retryer {
+			return gax.OnCodes([]codes.Code{
+				codes.Unavailable,
+				codes.DeadlineExceeded,
+			}, gax.Backoff{
+				Initial:    500 * time.Millisecond,
+				Max:        10 * time.Second,
+				Multiplier: 2.0,
+			})
+		}),
+	}
+}
+
+func waitDDLOp(ctx context.Context, op *dbadmin.UpdateDatabaseDdlOperation) error {
+	opts := pollCallOptions()
+	for !op.Done() {
+		if err := op.Poll(ctx, opts...); err != nil {
+			return err
+		}
+		if op.Done() {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(ddlPollInterval):
+		}
+	}
+	return nil
+}
+
+func waitCreateDBOp(ctx context.Context, op *dbadmin.CreateDatabaseOperation) error {
+	opts := pollCallOptions()
+	for !op.Done() {
+		if _, err := op.Poll(ctx, opts...); err != nil {
+			return err
+		}
+		if op.Done() {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(ddlPollInterval):
+		}
+	}
+	return nil
+}
+
+// execDDLsFast runs a batch of DDLs against databasePath using the admin
+// client with a short polling interval. Used only in test setup/teardown so
+// we don't wait on the generated client's 60-second default.
+func execDDLsFast(ctx context.Context, admin *dbadmin.DatabaseAdminClient, databasePath string, ddls []string) error {
+	if len(ddls) == 0 {
+		return nil
+	}
+	op, err := admin.UpdateDatabaseDdl(ctx, &databasepb.UpdateDatabaseDdlRequest{
+		Database:   databasePath,
+		Statements: ddls,
+	})
+	if err != nil {
+		return fmt.Errorf("UpdateDatabaseDdl: %v", err)
+	}
+	return waitDDLOp(ctx, op)
+}
+
+// Each test run produces unique database IDs so the test suite can
+// parallelise without colliding, and repeat runs against the same Omni
+// instance don't fight over stale databases.
+var (
+	testRunID      = time.Now().Unix() % 1_000_000
+	testDBSequence uint64
+)
+
+func uniqueDatabaseID() string {
+	n := atomic.AddUint64(&testDBSequence, 1)
+	return fmt.Sprintf("td%d-%d", testRunID, n)
+}
+
+// newTestDatabase creates a fresh, empty database for a single test and
+// returns both a Database handle and the underlying admin client so tests
+// can apply their own DDLs with fast polling. Cleanup (close + drop) is
+// registered with t.Cleanup.
+func newTestDatabase(t *testing.T, base Config) (*SpannerDatabase, *SpannerAdminDatabase) {
+	t.Helper()
+
+	config := base
+	config.DatabaseID = uniqueDatabaseID()
+
+	adminDB, err := NewAdminDatabase(config)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	op, err := adminDB.DatabaseAdminClient().CreateDatabase(ctx, &databasepb.CreateDatabaseRequest{
+		Parent:          "projects/" + config.ProjectID + "/instances/" + config.InstanceID,
+		CreateStatement: fmt.Sprintf("CREATE DATABASE `%s`", config.DatabaseID),
+	})
+	require.NoError(t, err)
+	require.NoError(t, waitCreateDBOp(ctx, op))
+
+	db, err := NewDatabase(config)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		db.Close()
+		// Drop asynchronously; we don't want teardown to block the next test
+		// from starting. If the drop itself errors (e.g. connection closed
+		// because Omni shut down) we don't care.
+		go func() {
+			_ = adminDB.DropDatabase(context.Background())
+			adminDB.Close()
+		}()
+	})
+
+	return db, adminDB
+}


### PR DESCRIPTION
## Summary

- CI integration tests now run against Spanner Omni on localhost:15000 (Emulator job and docker-compose removed)
- Omni-specific workarounds live entirely in test code — `spanner.go` is untouched
- Full suite runs in ~80–100s (down from ~300s sequential)

### Omni quirks handled in test code

- **`op.Wait` polls on a 1-minute interval** — fine against production Spanner but doubles wall time on Omni where DDL batches finish in ~tens of seconds. `testutil_test.go` adds a fast-polling helper (1s interval, 60s per-request timeout, retries on `DeadlineExceeded`) that setup/teardown DDLs go through directly via the admin client. The tests that specifically exercise `SpannerDatabase.ExecDDL(s)` keep the stock path so that code is still covered.
- **~30s bootstrap cost on the first CREATE TABLE in a fresh database** — drop/recreate-per-test would multiply out to 30+ minutes across the suite. Instead, every test creates its own freshly-named database and calls `t.Parallel()` on every subtest; with `-parallel 80` the bootstrap costs overlap and the suite finishes in ~80s.

### Other changes

- `make test` defaults to Omni (`SPANNER_EMULATOR_HOST=localhost:15000`, `project=default`, `instance=default`) with `-count=1` so it never returns a cached pass
- `make omni-up` / `make omni-down` helpers for the Omni container lifecycle
- README Testing section updated

## Test plan

- [x] `make omni-up && make test` — all 51 tests pass locally in ~80s
- [ ] CI run on the PR goes green